### PR TITLE
Update Chicken_Police.yaml

### DIFF
--- a/games/Chicken_Police.yaml
+++ b/games/Chicken_Police.yaml
@@ -72,7 +72,6 @@ tags:
     - bird
   misc:
     - engine-unity
-    - work-in-process
     - grayscale
     - full-audio
   lang:


### PR DESCRIPTION
公鸡神探已于11月6日正式发售，故可以去掉开发中的标签。
PS：话说不考虑一个获取商店价位的功能吗？这样子有打折啥的可以方便的显示出来……